### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ An AI-powered automation tool development platform, providing:
 🚀 Enterprise-Grade Capabilities - Integration of production environment services such as MongoDB/Redis/SSH
 🔄 Real-time Updates - Zero-downtime deployment via `buildReload_tool`
 
+<a href="https://glama.ai/mcp/servers/@xiaoguomeiyitian/ToolBox">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@xiaoguomeiyitian/ToolBox/badge" alt="ToolBox Server MCP server" />
+</a>
+
 ```mermaid
 graph LR
     A[Developer] -->|Create| B(Tool Template)


### PR DESCRIPTION
This PR adds a badge for the [ToolBox MCP Server](https://glama.ai/mcp/servers/@xiaoguomeiyitian/ToolBox) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@xiaoguomeiyitian/ToolBox">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@xiaoguomeiyitian/ToolBox/badge" alt="ToolBox Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.